### PR TITLE
Improve FAQ editor styling

### DIFF
--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -146,12 +146,28 @@ function fsco_render_faq_metabox($post) {
                     document.getElementById('faq-list').appendChild(item);
                     item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                     jQuery('#faq-list').sortable('refresh');
+
+                    // Prepopulate example values
+                    const cat = item.querySelector('input[name="faq_category[]"]');
+                    const q = item.querySelector('input[name="faq_question[]"]');
+                    const title = item.querySelector('.faq-title');
+                    if (cat) cat.value = 'Example Category';
+                    if (q) {
+                        q.value = 'Example question';
+                        if (title) title.textContent = 'Example question';
+                    }
+
                     const body = item.querySelector('.faq-body');
                     body.style.display = 'block';
                     setTimeout(() => {
                         wp.editor.initialize(`faq_answer_${fscoIndex}`, {
                             tinymce: true,
-                            quicktags: true
+                            quicktags: true,
+                            setup: function (ed) {
+                                ed.on('init', function () {
+                                    ed.setContent('Example answer');
+                                });
+                            }
                         });
                     }, 10);
                     fscoIndex++;

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -11,6 +11,7 @@ add_action('admin_enqueue_scripts', function ($hook) {
     if ((int) $post_id !== 9196) return;
 
     wp_enqueue_editor();
+    wp_enqueue_script('jquery-ui-sortable');
     wp_enqueue_script('fsco-faq-editor', admin_url('admin-ajax.php'), [], null, true);
     wp_localize_script('fsco-faq-editor', 'FSFAQ', [
         'ajax_url' => admin_url('admin-ajax.php'),
@@ -37,6 +38,9 @@ function fsco_render_faq_metabox($post) {
             gap: 12px;
             margin-bottom: 16px;
         }
+        .fsfaq-controls .fsfaq-btn {
+            min-width: 80px;
+        }
         .faq-item {
             border: 1px solid #ddd;
             border-radius: 6px;
@@ -53,6 +57,14 @@ function fsco_render_faq_metabox($post) {
             justify-content: space-between;
             align-items: center;
             cursor: pointer;
+        }
+        .faq-header span.faq-title {
+            flex: 1;
+        }
+        .faq-sort-handle {
+            cursor: move;
+            margin-right: 8px;
+            color: #888;
         }
         .faq-remove-btn {
             background: transparent;
@@ -77,19 +89,27 @@ function fsco_render_faq_metabox($post) {
             border-radius: 4px;
             border: 1px solid #ccc;
         }
+        .faq-col.question {
+            flex: 1;
+        }
+        .faq-sort-placeholder {
+            border: 1px dashed #ccc;
+            height: 38px;
+            margin-bottom: 12px;
+        }
     </style>
 
     <div class="fsfaq-controls">
-        <button type="button" class="button button-primary" onclick="fscoAddFaq()">+ Add FAQ</button>
+        <button type="button" class="button button-primary fsfaq-btn" onclick="fscoAddFaq()">+ Add FAQ</button>
         <select id="faq-filter" onchange="fscoFilterFaqs(this.value)">
             <option value="">All Categories</option>
             <?php foreach ($categories as $cat): ?>
                 <option value="<?php echo esc_attr($cat); ?>"><?php echo esc_html($cat); ?></option>
             <?php endforeach; ?>
         </select>
-        <button type="button" onclick="fscoExportFaqs()">Export</button>
+        <button type="button" class="button button-primary fsfaq-btn" onclick="fscoExportFaqs()">Export</button>
         <label>
-            <button type="button" onclick="document.getElementById('fsco-import').click()">Import</button>
+            <button type="button" class="button button-primary fsfaq-btn" onclick="document.getElementById('fsco-import').click()">Import</button>
             <input type="file" id="fsco-import" accept=".json" style="display:none" onchange="fscoImportFaqs(this)">
         </label>
     </div>
@@ -103,6 +123,14 @@ function fsco_render_faq_metabox($post) {
     <script>
     let fscoIndex = <?php echo count($faqs); ?>;
 
+    function fscoToggleFaqBody(e) {
+        if (e && e.target.closest('.faq-remove-btn, .faq-sort-handle')) return;
+        const body = this.nextElementSibling;
+        const open = body.style.display === "block";
+        document.querySelectorAll('.faq-body').forEach(b => b.style.display = 'none');
+        body.style.display = open ? 'none' : 'block';
+    }
+
     function fscoAddFaq() {
         const form = new FormData();
         form.append('action', 'fsco_add_faq_row');
@@ -114,11 +142,16 @@ function fsco_render_faq_metabox($post) {
                 if (data.success) {
                     const wrap = document.createElement('div');
                     wrap.innerHTML = data.data;
-                    document.getElementById('faq-list').appendChild(wrap);
-                    wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                        tinymce: true,
-                        quicktags: true
-                    });
+                    const item = wrap.firstElementChild;
+                    document.getElementById('faq-list').appendChild(item);
+                    item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
+                    jQuery('#faq-list').sortable('refresh');
+                    setTimeout(() => {
+                        wp.editor.initialize(`faq_answer_${fscoIndex}`, {
+                            tinymce: true,
+                            quicktags: true
+                        });
+                    }, 10);
                     fscoIndex++;
                 }
             });
@@ -169,20 +202,24 @@ function fsco_render_faq_metabox($post) {
                             if (r.success) {
                                 const wrap = document.createElement('div');
                                 wrap.innerHTML = r.data;
-                                list.appendChild(wrap);
-                                const newItem = list.lastElementChild;
+                                const newItem = wrap.firstElementChild;
+                                list.appendChild(newItem);
                                 newItem.querySelector('input[name="faq_category[]"]').value = f.category || '';
                                 newItem.querySelector('input[name="faq_question[]"]').value = f.question || '';
-                                newItem.querySelector('.faq-header span').textContent = f.question || 'Untitled FAQ';
-                                wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                                    tinymce: true,
-                                    quicktags: true,
-                                    setup: function (ed) {
-                                        ed.on('init', function () {
-                                            ed.setContent(f.answer || '');
-                                        });
-                                    }
-                                });
+                                newItem.querySelector('.faq-title').textContent = f.question || 'Untitled FAQ';
+                                newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
+                                jQuery('#faq-list').sortable('refresh');
+                                setTimeout(() => {
+                                    wp.editor.initialize(`faq_answer_${fscoIndex}`, {
+                                        tinymce: true,
+                                        quicktags: true,
+                                        setup: function (ed) {
+                                            ed.on('init', function () {
+                                                ed.setContent(f.answer || '');
+                                            });
+                                        }
+                                    });
+                                }, 10);
                                 fscoIndex++;
                             }
                         });
@@ -196,12 +233,12 @@ function fsco_render_faq_metabox($post) {
 
     document.addEventListener("DOMContentLoaded", () => {
         document.querySelectorAll(".faq-header").forEach(h => {
-            h.addEventListener("click", function () {
-                const body = this.nextElementSibling;
-                const open = body.style.display === "block";
-                document.querySelectorAll(".faq-body").forEach(b => b.style.display = "none");
-                body.style.display = open ? "none" : "block";
-            });
+            h.addEventListener("click", fscoToggleFaqBody);
+        });
+        jQuery('#faq-list').sortable({
+            handle: '.faq-sort-handle',
+            items: '.faq-item',
+            placeholder: 'faq-sort-placeholder'
         });
     });
     </script>
@@ -213,7 +250,8 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
     ?>
     <div class="faq-item" data-category="<?php echo esc_attr($cat); ?>">
         <div class="faq-header">
-            <span><?php echo esc_html($q ?: 'Untitled FAQ'); ?></span>
+            <span class="faq-sort-handle dashicons dashicons-move" aria-hidden="true"></span>
+            <span class="faq-title"><?php echo esc_html($q ?: 'Untitled FAQ'); ?></span>
             <button type="button" class="faq-remove-btn" onclick="this.closest('.faq-item').remove()">×</button>
         </div>
         <div class="faq-body">
@@ -223,10 +261,10 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
                     <input type="text" name="faq_category[]" value="<?php echo esc_attr($cat); ?>"
                         oninput="this.closest('.faq-item').setAttribute('data-category', this.value)">
                 </div>
-                <div class="faq-col">
+                <div class="faq-col question">
                     <label>Question</label>
                     <input type="text" name="faq_question[]" value="<?php echo esc_attr($q); ?>"
-                        oninput="this.closest('.faq-item').querySelector('.faq-header span').textContent = (this.value || 'Untitled FAQ')">
+                        oninput="this.closest('.faq-item').querySelector('.faq-title').textContent = (this.value || 'Untitled FAQ')">
                 </div>
             </div>
             <label>Answer</label>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -146,11 +146,14 @@ function fsco_render_faq_metabox($post) {
                     document.getElementById('faq-list').appendChild(item);
                     item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                     jQuery('#faq-list').sortable('refresh');
+                    const body = item.querySelector('.faq-body');
+                    body.style.display = 'block';
                     setTimeout(() => {
                         wp.editor.initialize(`faq_answer_${fscoIndex}`, {
                             tinymce: true,
                             quicktags: true
                         });
+                        body.style.display = '';
                     }, 10);
                     fscoIndex++;
                 }
@@ -209,6 +212,8 @@ function fsco_render_faq_metabox($post) {
                                 newItem.querySelector('.faq-title').textContent = f.question || 'Untitled FAQ';
                                 newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                                 jQuery('#faq-list').sortable('refresh');
+                                const body = newItem.querySelector('.faq-body');
+                                body.style.display = 'block';
                                 setTimeout(() => {
                                     wp.editor.initialize(`faq_answer_${fscoIndex}`, {
                                         tinymce: true,
@@ -219,6 +224,7 @@ function fsco_render_faq_metabox($post) {
                                             });
                                         }
                                     });
+                                    body.style.display = '';
                                 }, 10);
                                 fscoIndex++;
                             }

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -153,7 +153,6 @@ function fsco_render_faq_metabox($post) {
                             tinymce: true,
                             quicktags: true
                         });
-                        body.style.display = '';
                     }, 10);
                     fscoIndex++;
                 }


### PR DESCRIPTION
## Summary
- refactor FAQ item header with sort handle and consistent title span
- allow drag-and-drop sorting with jQuery UI
- fix WYSIWYG init for new/imported FAQs
- style buttons consistently and tweak layout
- ensure question inputs stretch across the row

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc0f7623c832686128850340c7be4