### PR TITLE
Enable Quicktags editor for FAQs

### DIFF
--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -10,8 +10,6 @@ add_action('admin_enqueue_scripts', function ($hook) {
     $post_id = $_GET['post'] ?? null;
     if ((int) $post_id !== 9196) return;
 
-    wp_enqueue_editor();
-    wp_enqueue_script('quicktags');
     wp_enqueue_script('jquery-ui-sortable');
     wp_enqueue_style('dashicons');
     wp_enqueue_script('fsco-faq-editor', admin_url('admin-ajax.php'), [], null, true);
@@ -163,10 +161,6 @@ function fsco_render_faq_metabox($post) {
                         const catInput = item.querySelector('input[name="faq_category[]"]');
                         if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
                     }
-                    wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                        tinymce: false,
-                        quicktags: true
-                    });
                     fscoUpdateCategoryList();
                     fscoIndex++;
                 }
@@ -186,16 +180,15 @@ function fsco_render_faq_metabox($post) {
             const cat = item.querySelector('input[name="faq_category[]"]').value;
             const q = item.querySelector('input[name="faq_question[]"]').value;
             const textarea = item.querySelector('textarea');
-            const editor = textarea ? tinyMCE.get(textarea.id) : null;
-            const a = editor ? editor.getContent() : (textarea ? textarea.value : '');
-            if (q.trim()) faqs.push({ category: cat, question: q, answer: a });
+            const answer = textarea ? textarea.value : "";
+            if (q.trim()) faqs.push({ category: cat, question: q, answer: answer });
         });
-        const blob = new Blob([JSON.stringify(faqs, null, 2)], { type: 'application/json' });
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = 'faqs.json';
-        a.click();
-        URL.revokeObjectURL(a.href);
+        const blob = new Blob([JSON.stringify(faqs, null, 2)], { type: "application/json" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = "faqs.json";
+        link.click();
+        URL.revokeObjectURL(link.href);
     }
 
     function fscoImportFaqs(input) {
@@ -228,10 +221,6 @@ function fsco_render_faq_metabox($post) {
                                 newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                                 const catInput = newItem.querySelector('input[name="faq_category[]"]');
                                 if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
-                                wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                                    tinymce: false,
-                                    quicktags: true
-                                });
                                 document.getElementById(`faq_answer_${fscoIndex}`).value = f.answer || '';
                                 fscoUpdateCategoryList();
                                 fscoIndex++;
@@ -288,14 +277,7 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
             </div>
             <label>Answer</label>
             <?php
-            wp_editor($a, "faq_answer_$i", [
-                'textarea_name' => 'faq_answer[]',
-                'textarea_rows' => 6,
-                'editor_height' => 160,
-                'tinymce'       => false,
-                'quicktags'     => true,
-                'media_buttons' => false,
-            ]);
+            <textarea id="faq_answer_<?php echo $i; ?>" name="faq_answer[]" rows="6" style="width:100%;"><?php echo esc_textarea($a); ?></textarea>
             ?>
         </div>
     </div>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -1,3 +1,4 @@
+<?php
 add_action('add_meta_boxes', function () {
     $post_id = $_GET['post'] ?? $_POST['post_ID'] ?? null;
     if ((int) $post_id === 9196) {
@@ -12,6 +13,7 @@ add_action('admin_enqueue_scripts', function ($hook) {
 
     wp_enqueue_script('jquery-ui-sortable');
     wp_enqueue_style('dashicons');
+    wp_enqueue_script('quicktags');
     wp_enqueue_script('fsco-faq-editor', admin_url('admin-ajax.php'), [], null, true);
     wp_localize_script('fsco-faq-editor', 'FSFAQ', [
         'ajax_url' => admin_url('admin-ajax.php'),
@@ -160,6 +162,10 @@ function fsco_render_faq_metabox($post) {
                         item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                         const catInput = item.querySelector('input[name="faq_category[]"]');
                         if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
+                        wp.editor.initialize(`faq_answer_${fscoIndex}`, {
+                            tinymce: false,
+                            quicktags: true
+                        });
                     }
                     fscoUpdateCategoryList();
                     fscoIndex++;
@@ -178,10 +184,13 @@ function fsco_render_faq_metabox($post) {
         const faqs = [];
         document.querySelectorAll('.faq-item').forEach(item => {
             const cat = item.querySelector('input[name="faq_category[]"]').value;
-            const q = item.querySelector('input[name="faq_question[]"]').value;
+            const q   = item.querySelector('input[name="faq_question[]"]').value;
             const textarea = item.querySelector('textarea');
-            const answer = textarea ? textarea.value : "";
-            if (q.trim()) faqs.push({ category: cat, question: q, answer: answer });
+            const id = textarea ? textarea.id : '';
+            const editor = window.tinyMCE ? tinyMCE.get(id) : null;
+            const answer = editor ? editor.getContent() :
+                (textarea ? textarea.value : '');
+            if (q.trim()) faqs.push({ category: cat, question: q, answer });
         });
         const blob = new Blob([JSON.stringify(faqs, null, 2)], { type: "application/json" });
         const link = document.createElement("a");
@@ -222,6 +231,10 @@ function fsco_render_faq_metabox($post) {
                                 const catInput = newItem.querySelector('input[name="faq_category[]"]');
                                 if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
                                 document.getElementById(`faq_answer_${fscoIndex}`).value = f.answer || '';
+                                wp.editor.initialize(`faq_answer_${fscoIndex}`, {
+                                    tinymce: false,
+                                    quicktags: true
+                                });
                                 fscoUpdateCategoryList();
                                 fscoIndex++;
                             }
@@ -277,7 +290,14 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
             </div>
             <label>Answer</label>
             <?php
-            <textarea id="faq_answer_<?php echo $i; ?>" name="faq_answer[]" rows="6" style="width:100%;"><?php echo esc_textarea($a); ?></textarea>
+            wp_editor($a, "faq_answer_$i", [
+                'textarea_name' => 'faq_answer[]',
+                'textarea_rows' => 6,
+                'editor_height' => 160,
+                'tinymce'       => false,
+                'quicktags'     => true,
+                'media_buttons' => false,
+            ]);
             ?>
         </div>
     </div>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -12,6 +12,8 @@ add_action('admin_enqueue_scripts', function ($hook) {
 
     wp_enqueue_editor();
     wp_enqueue_script('quicktags');
+    wp_enqueue_script('jquery-ui-sortable');
+    wp_enqueue_style('dashicons');
     wp_enqueue_script('fsco-faq-editor', admin_url('admin-ajax.php'), [], null, true);
     wp_localize_script('fsco-faq-editor', 'FSFAQ', [
         'ajax_url' => admin_url('admin-ajax.php'),
@@ -66,6 +68,17 @@ function fsco_render_faq_metabox($post) {
             padding: 16px;
             display: none;
         }
+        .drag-handle {
+            cursor: move;
+            margin-right: 6px;
+            color: #888;
+        }
+        .faq-sort-placeholder {
+            background: #f1f1f1;
+            border: 1px dashed #ccc;
+            height: 64px;
+            margin-bottom: 12px;
+        }
         .faq-row {
             display: flex;
             gap: 12px;
@@ -109,6 +122,21 @@ function fsco_render_faq_metabox($post) {
     <script>
     let fscoIndex = <?php echo count($faqs); ?>;
 
+    function fscoUpdateCategoryList() {
+        const list = document.getElementById('fsfaq-category-options');
+        const cats = new Set();
+        document.querySelectorAll('input[name="faq_category[]"]').forEach(el => {
+            const v = el.value.trim();
+            if (v) cats.add(v);
+        });
+        list.innerHTML = '';
+        cats.forEach(cat => {
+            const opt = document.createElement('option');
+            opt.value = cat;
+            list.appendChild(opt);
+        });
+    }
+
     function fscoToggleFaqBody() {
         const body = this.nextElementSibling;
         const open = body.style.display === "block";
@@ -129,11 +157,16 @@ function fsco_render_faq_metabox($post) {
                     wrap.innerHTML = data.data;
                     document.getElementById('faq-list').appendChild(wrap);
                     const item = wrap.querySelector('.faq-item');
-                    if (item) item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
+                    if (item) {
+                        item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
+                        const catInput = item.querySelector('input[name="faq_category[]"]');
+                        if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
+                    }
                     wp.editor.initialize(`faq_answer_${fscoIndex}`, {
                         tinymce: false,
                         quicktags: true
                     });
+                    fscoUpdateCategoryList();
                     fscoIndex++;
                 }
             });
@@ -148,12 +181,12 @@ function fsco_render_faq_metabox($post) {
 
     function fscoExportFaqs() {
         const faqs = [];
-        document.querySelectorAll('.faq-item').forEach((item, i) => {
+        document.querySelectorAll('.faq-item').forEach(item => {
             const cat = item.querySelector('input[name="faq_category[]"]').value;
             const q = item.querySelector('input[name="faq_question[]"]').value;
-            const editor = tinyMCE.get(`faq_answer_${i}`);
-            const a = editor ? editor.getContent() :
-                        document.getElementById(`faq_answer_${i}`).value;
+            const textarea = item.querySelector('textarea');
+            const editor = textarea ? tinyMCE.get(textarea.id) : null;
+            const a = editor ? editor.getContent() : (textarea ? textarea.value : '');
             if (q.trim()) faqs.push({ category: cat, question: q, answer: a });
         });
         const blob = new Blob([JSON.stringify(faqs, null, 2)], { type: 'application/json' });
@@ -192,11 +225,14 @@ function fsco_render_faq_metabox($post) {
                                 newItem.querySelector('input[name="faq_question[]"]').value = f.question || '';
                                 newItem.querySelector('.faq-header span').textContent = f.question || 'Untitled FAQ';
                                 newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
+                                const catInput = newItem.querySelector('input[name="faq_category[]"]');
+                                if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
                                 wp.editor.initialize(`faq_answer_${fscoIndex}`, {
                                     tinymce: false,
                                     quicktags: true
                                 });
                                 document.getElementById(`faq_answer_${fscoIndex}`).value = f.answer || '';
+                                fscoUpdateCategoryList();
                                 fscoIndex++;
                             }
                         });
@@ -212,6 +248,16 @@ function fsco_render_faq_metabox($post) {
         document.querySelectorAll(".faq-header").forEach(h => {
             h.addEventListener("click", fscoToggleFaqBody);
         });
+        document.querySelectorAll('input[name="faq_category[]"]').forEach(c => {
+            c.addEventListener('input', fscoUpdateCategoryList);
+        });
+        fscoUpdateCategoryList();
+        jQuery(function($){
+            $('#faq-list').sortable({
+                handle: '.drag-handle',
+                placeholder: 'faq-sort-placeholder'
+            });
+        });
     });
     </script>
     <?php
@@ -222,6 +268,7 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
     ?>
     <div class="faq-item" data-category="<?php echo esc_attr($cat); ?>">
         <div class="faq-header">
+            <span class="dashicons dashicons-move drag-handle"></span>
             <span><?php echo esc_html($q ?: 'Untitled FAQ'); ?></span>
             <button type="button" class="faq-remove-btn" onclick="this.closest('.faq-item').remove()">×</button>
         </div>
@@ -230,7 +277,7 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
                 <div class="faq-col" style="flex:0 0 160px;">
                     <label>Category</label>
                     <input type="text" name="faq_category[]" list="fsfaq-category-options" value="<?php echo esc_attr($cat); ?>"
-                        oninput="this.closest('.faq-item').setAttribute('data-category', this.value)">
+                        oninput="this.closest('.faq-item').setAttribute('data-category', this.value); fscoUpdateCategoryList();">
                 </div>
                 <div class="faq-col" style="flex:1;">
                     <label>Question</label>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -88,12 +88,17 @@ function fsco_render_faq_metabox($post) {
                 <option value="<?php echo esc_attr($cat); ?>"><?php echo esc_html($cat); ?></option>
             <?php endforeach; ?>
         </select>
-        <button type="button" onclick="fscoExportFaqs()">Export</button>
+        <button type="button" class="button button-primary" onclick="fscoExportFaqs()">Export</button>
         <label>
-            <button type="button" onclick="document.getElementById('fsco-import').click()">Import</button>
+            <button type="button" class="button button-primary" onclick="document.getElementById('fsco-import').click()">Import</button>
             <input type="file" id="fsco-import" accept=".json" style="display:none" onchange="fscoImportFaqs(this)">
         </label>
     </div>
+    <datalist id="fsfaq-category-options">
+        <?php foreach ($categories as $cat): ?>
+            <option value="<?php echo esc_attr($cat); ?>"></option>
+        <?php endforeach; ?>
+    </datalist>
 
     <div id="faq-list">
         <?php foreach ($faqs as $i => $faq) {
@@ -224,10 +229,10 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
             <div class="faq-row">
                 <div class="faq-col" style="flex:0 0 160px;">
                     <label>Category</label>
-                    <input type="text" name="faq_category[]" value="<?php echo esc_attr($cat); ?>"
+                    <input type="text" name="faq_category[]" list="fsfaq-category-options" value="<?php echo esc_attr($cat); ?>"
                         oninput="this.closest('.faq-item').setAttribute('data-category', this.value)">
                 </div>
-                <div class="faq-col">
+                <div class="faq-col" style="flex:1;">
                     <label>Question</label>
                     <input type="text" name="faq_question[]" value="<?php echo esc_attr($q); ?>"
                         oninput="this.closest('.faq-item').querySelector('.faq-header span').textContent = (this.value || 'Untitled FAQ')">

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -125,7 +125,7 @@ function fsco_render_faq_metabox($post) {
                     const item = wrap.querySelector('.faq-item');
                     if (item) item.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                     wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                        tinymce: true,
+                        tinymce: false,
                         quicktags: true
                     });
                     fscoIndex++;
@@ -145,7 +145,9 @@ function fsco_render_faq_metabox($post) {
         document.querySelectorAll('.faq-item').forEach((item, i) => {
             const cat = item.querySelector('input[name="faq_category[]"]').value;
             const q = item.querySelector('input[name="faq_question[]"]').value;
-            const a = tinyMCE.get(`faq_answer_${i}`)?.getContent() || '';
+            const editor = tinyMCE.get(`faq_answer_${i}`);
+            const a = editor ? editor.getContent() :
+                        document.getElementById(`faq_answer_${i}`).value;
             if (q.trim()) faqs.push({ category: cat, question: q, answer: a });
         });
         const blob = new Blob([JSON.stringify(faqs, null, 2)], { type: 'application/json' });
@@ -185,14 +187,10 @@ function fsco_render_faq_metabox($post) {
                                 newItem.querySelector('.faq-header span').textContent = f.question || 'Untitled FAQ';
                                 newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                                 wp.editor.initialize(`faq_answer_${fscoIndex}`, {
-                                    tinymce: true,
-                                    quicktags: true,
-                                    setup: function (ed) {
-                                        ed.on('init', function () {
-                                            ed.setContent(f.answer || '');
-                                        });
-                                    }
+                                    tinymce: false,
+                                    quicktags: true
                                 });
+                                document.getElementById(`faq_answer_${fscoIndex}`).value = f.answer || '';
                                 fscoIndex++;
                             }
                         });
@@ -240,7 +238,8 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
                 'textarea_name' => 'faq_answer[]',
                 'textarea_rows' => 6,
                 'editor_height' => 160,
-                'tinymce' => true,
+                'tinymce'       => false,
+                'quicktags'     => true,
                 'media_buttons' => false,
             ]);
             ?>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -53,7 +53,7 @@ function fsco_render_faq_metabox($post) {
             padding: 10px 16px;
             font-weight: 600;
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-start;
             align-items: center;
             cursor: pointer;
         }
@@ -63,6 +63,7 @@ function fsco_render_faq_metabox($post) {
             font-size: 20px;
             color: #888;
             cursor: pointer;
+            margin-left: auto;
         }
         .faq-body {
             padding: 16px;
@@ -223,7 +224,7 @@ function fsco_render_faq_metabox($post) {
                                 const newItem = list.lastElementChild;
                                 newItem.querySelector('input[name="faq_category[]"]').value = f.category || '';
                                 newItem.querySelector('input[name="faq_question[]"]').value = f.question || '';
-                                newItem.querySelector('.faq-header span').textContent = f.question || 'Untitled FAQ';
+                                newItem.querySelector('.faq-title').textContent = f.question || 'Untitled FAQ';
                                 newItem.querySelector('.faq-header').addEventListener('click', fscoToggleFaqBody);
                                 const catInput = newItem.querySelector('input[name="faq_category[]"]');
                                 if (catInput) catInput.addEventListener('input', fscoUpdateCategoryList);
@@ -269,7 +270,7 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
     <div class="faq-item" data-category="<?php echo esc_attr($cat); ?>">
         <div class="faq-header">
             <span class="dashicons dashicons-move drag-handle"></span>
-            <span><?php echo esc_html($q ?: 'Untitled FAQ'); ?></span>
+            <span class="faq-title"><?php echo esc_html($q ?: 'Untitled FAQ'); ?></span>
             <button type="button" class="faq-remove-btn" onclick="this.closest('.faq-item').remove()">×</button>
         </div>
         <div class="faq-body">
@@ -282,7 +283,7 @@ function fsco_render_faq_item($cat = '', $q = '', $a = '', $i = 0) {
                 <div class="faq-col" style="flex:1;">
                     <label>Question</label>
                     <input type="text" name="faq_question[]" value="<?php echo esc_attr($q); ?>"
-                        oninput="this.closest('.faq-item').querySelector('.faq-header span').textContent = (this.value || 'Untitled FAQ')">
+                        oninput="this.closest('.faq-item').querySelector('.faq-title').textContent = (this.value || 'Untitled FAQ')">
                 </div>
             </div>
             <label>Answer</label>

--- a/snippet file for faq page
+++ b/snippet file for faq page
@@ -11,6 +11,7 @@ add_action('admin_enqueue_scripts', function ($hook) {
     if ((int) $post_id !== 9196) return;
 
     wp_enqueue_editor();
+    wp_enqueue_script('quicktags');
     wp_enqueue_script('fsco-faq-editor', admin_url('admin-ajax.php'), [], null, true);
     wp_localize_script('fsco-faq-editor', 'FSFAQ', [
         'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
## Summary
- disable TinyMCE and enable Quicktags in `fsco_render_faq_item`
- adjust JS to initialise Quicktags only and set textarea value on import
- update export function to read from the textarea if TinyMCE isn't present

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fcf3196608326bc0137b19598e0f8